### PR TITLE
Replace xhtml-combinators with blaze

### DIFF
--- a/snap-website.cabal
+++ b/snap-website.cabal
@@ -29,13 +29,13 @@ Executable snap-website
     process,
     snap        >= 0.9 && <0.10,
     snap-core   >= 0.9 && <0.10,
+    snap-blaze  >= 0.2.1 && <0.3,
     snap-server >= 0.9 && <0.10,
     snap-static-pages >= 0.2 && <0.3,
     text,
     time,
     transformers,
     utf8-string,
-    xhtml-combinators >= 0.2.2 && < 0.3,
     xmlhtml >= 0.1 && < 0.3
 
   ghc-prof-options: -prof -auto-all


### PR DESCRIPTION
xhtml-combinators was being used only for it's text -> html escape function, and
even then that was only for the error page. Rather than bring in a new
dependency on this, I've rewritten the code to use blaze-html instead - which we
already have a transitive dependency on through heist. I've also used snap-blaze
to do the final rendering, so we can somewhat dog food our own libraries.
