### PR TITLE
Add a 'Talks' section to documentation

### DIFF
--- a/snaplets/heist/templates/docs.tpl
+++ b/snaplets/heist/templates/docs.tpl
@@ -121,7 +121,7 @@
             <dt>
               <a href="http://vimeo.com/59109358">Building a Link Shortener with
               Snaplets</a><br />
-              Ryan Trinkle, Jan 2013
+              Ryan Trinkle, NY Haskell User Group, Jan 2013
             </dt>
             <dd style="height: auto">
               <iframe src="http://player.vimeo.com/video/59109358"


### PR DESCRIPTION
I felt like it would be nice if we had some more material on the docs page, and this talk is fantastic and deserved to be shared more!
