### PR TITLE
Fixed typo in compilation recommendation.

### DIFF
--- a/snaplets/heist/templates/docs/style-guide.md
+++ b/snaplets/heist/templates/docs/style-guide.md
@@ -225,6 +225,6 @@ abbreviation.  For example, write `HttpServer` instead of
 
 ### Warnings ###
 
-Code should be compilable with `-Wall -Werror -Wno-warn-unused-binds`.
+Code should be compilable with `-Wall -Werror -fno-warn-unused-binds`.
 There should be no warnings.
 


### PR DESCRIPTION
ghc throws an "unrecognised flag" error for the `-Wno-warn-unused-binds` flag.
I assume that the `-fno-warn-unused-binds` flag was meant.
